### PR TITLE
Fixed bug in which default value was not set.

### DIFF
--- a/inline-edit.html
+++ b/inline-edit.html
@@ -42,6 +42,7 @@
       },
 
       ready: function() {
+          this._stuffChanged();
       },
 
       _stuffChanged: function() {


### PR DESCRIPTION
On page load, the paper-input had a default value of N/A even if a value="" was specified. So at the beginning of the element (inside the ready function) we run the _stuffChanged method to see if there is a value="" set.